### PR TITLE
Fix Jest config bug in user service

### DIFF
--- a/packages/user-service/jest.config.js
+++ b/packages/user-service/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },
   passWithNoTests: true,


### PR DESCRIPTION
## Summary
- fix `moduleNameMapper` property in user service test config

## Testing
- `pnpm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_683fffa87dac832ea713b142640b805d